### PR TITLE
Adding cookie_secure option (defaults to false)

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -23,7 +23,7 @@ class Module
         if ($sm->has('session_save_handler', false)) {
             $saveHandler = $sm->get('session_save_handler');
         }
-        
+
         $sessionManager = new SessionManager($config, $storage, $saveHandler);
         Container::setDefaultManager($sessionManager);
 
@@ -55,6 +55,7 @@ class Module
                 'use_cookies' => true,
                 'use_only_cookies' => true,
                 'cookie_httponly' => true,
+                'cookie_secure' => false,
                 'name' => 'ZF2_SESSION',
                 ),
         );

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #AkrabatSession
 
-This ZF2 module is intended to make it simple to change the settings of a 
+This ZF2 module is intended to make it simple to change the settings of a
 session; specifically the most common change required is to set a name for
 the cookie used to hold the session id.
 
@@ -23,11 +23,11 @@ You can also just clone the module into your `./vendor/` directory or download i
 
 ## Configuration
 
-Once you have installed AkrabatSession, you need to enable it by editing 
+Once you have installed AkrabatSession, you need to enable it by editing
 `config/application.config.php` and adding `AkrabatSession` to the `modules`
 section.
 
-To configure the session as you required, add the following to your 
+To configure the session as you required, add the following to your
 `config/autoload/global.php` file:
 
         'session' => array(
@@ -51,6 +51,7 @@ Some of the more useful ones are:
 * `save_path` - By default, the path where the session files are created
 * `cookie_httponly` - Marks the cookie as accessible only through the HTTP protocol.
 * `use_only_cookies` - Specifies that only cookies are used and not session ids in URLs
+* `cookie_secure` - Specifies that cookies should only be sent over secure connections
 
 Note: `AkrabatSession` sets the `cookie_httponly` and `use_only_cookies` settings to true
 


### PR DESCRIPTION
Tested that setting this to true in my application's global (or local) config causes PHP to mark the session cookie with the "encrypted/secure connections only" flag:

![screen shot 2015-03-27 at 12 40 26 pm](https://cloud.githubusercontent.com/assets/136907/6874645/7be0a362-d47e-11e4-9f72-37f018bf7b3f.png)

![screen shot 2015-03-27 at 12 39 26 pm](https://cloud.githubusercontent.com/assets/136907/6874627/5a2a6c12-d47e-11e4-854e-5271de5b8353.png)
