### PR TITLE
Only specify used ZF2 modules, plus gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zendframework": "2.*"
+        "zendframework/zend-session": "2.*",
+        "zendframework/zend-servicemanager": "2.*"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Mentioned in #4 

Added the 2 modules that are used in the session module (based on the namespaces used).  Without tests local to this module I'm not sure if any other modules are necessary.

Added the .gitignore since the local composer update writes the vendor dir and composer.lock.
